### PR TITLE
Remove duplicate Anonymization CA definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4276,9 +4276,6 @@ under [=[RP]=] policy.
         are, in general, distinguishable only with externally provided knowledge regarding the contents of the [=attestation
         certificates=] conveyed in the [=attestation statement=].
 
-: <dfn>Anonymization CA</dfn> (<dfn>AnonCA</dfn>)
-:: In this case, the [=authenticator=] works with a cloud-operated [=Anonymization CA=] owned by its manufacturer to dynamically generate per-[=credential=] [=attestation certificates=] on the CA such that no identification information of the [=authenticator=] will be revealed to [=[RPS]=] in the [=attestation statement=].
-
 : No attestation statement (<dfn>None</dfn>)
 :: In this case, no attestation information is available. See also [[#sctn-none-attestation]].
 


### PR DESCRIPTION
There was a build error caused by this being defined twice. 